### PR TITLE
Explicit “#include <string>” in Utils/Exception.h

### DIFF
--- a/inc/L4/Utils/Exception.h
+++ b/inc/L4/Utils/Exception.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <stdexcept>
 
 namespace L4


### PR DESCRIPTION
Without this include, building L4 with `cmake` fails with an error about an attempt to instantiate an undefined template:

![screen shot 2017-09-29 at 4 29 06 pm](https://user-images.githubusercontent.com/378969/31034789-86fa90a4-a533-11e7-8590-435a0a929b66.jpg)

… adding the include fixed the problem for me.